### PR TITLE
Smart redraw

### DIFF
--- a/python/core/auto_generated/qgsmaplayerrenderer.sip.in
+++ b/python/core/auto_generated/qgsmaplayerrenderer.sip.in
@@ -96,7 +96,7 @@ Returns the render context associated with the renderer.
 %End
 
 
-    bool canComposeImage() const;
+    bool isReadyToCompose() const;
 %Docstring
 Returns whether the renderer already drawn (at
 least partially) some data to resulting image

--- a/python/core/auto_generated/qgsmaplayerrenderer.sip.in
+++ b/python/core/auto_generated/qgsmaplayerrenderer.sip.in
@@ -96,7 +96,17 @@ Returns the render context associated with the renderer.
 %End
 
 
+    bool canComposeImage() const;
+%Docstring
+Returns whether the renderer already drawn (at
+least partially) some data to resulting image
+
+.. versionadded:: 3.18
+%End
+
   protected:
+
+
 
 };
 

--- a/python/core/auto_generated/qgsmaprenderercache.sip.in
+++ b/python/core/auto_generated/qgsmaprenderercache.sip.in
@@ -107,7 +107,7 @@ Returns a null image if it is not cached.
 .. seealso:: :py:func:`hasCacheImage`
 %End
 
-    QImage transformedCacheImage( const QString &cacheKey, const QgsRectangle &extent, const QgsMapToPixel &mtp ) const;
+    QImage transformedCacheImage( const QString &cacheKey, const QgsMapToPixel &mtp ) const;
 %Docstring
 Returns the cached image for the specified ``cacheKey`` transformed
 to the particular extent and scale.

--- a/python/core/auto_generated/qgsmaprenderercache.sip.in
+++ b/python/core/auto_generated/qgsmaprenderercache.sip.in
@@ -21,6 +21,10 @@ the cache listens to :py:func:`~repaintRequested` signals from dependent layers.
 If triggered, the cache removes the rendered image (and disconnects from the
 layers).
 
+When user pans/zooms the canvas, the cache is also used in rendering period
+for particular layer after first render update and moment layer actually
+partially rendered something in the resulting image
+
 The class is thread-safe (multiple classes can access the same instance safely).
 
 .. versionadded:: 2.4
@@ -40,15 +44,28 @@ Invalidates the cache contents, clearing all cached images.
 .. seealso:: :py:func:`clearCacheImage`
 %End
 
-    bool init( const QgsRectangle &extent, double scale );
+    bool init( const QgsRectangle &extent, double scale ) /Deprecated/;
 %Docstring
-Initialize cache: set new parameters and clears the cache if any
+Initialize cache: sets extent and scale parameters and clears the cache if any
 parameters have changed since last initialization.
+
+Deprecated, use :py:func:`~QgsMapRendererCache.updateParameters` and :py:func:`~QgsMapRendererCache.clear`
 
 :return: flag whether the parameters are the same as last time
 %End
 
-    void setCacheImage( const QString &cacheKey, const QImage &image, const QList< QgsMapLayer * > &dependentLayers = QList< QgsMapLayer * >() );
+    bool updateParameters( const QgsRectangle &extent, double scale );
+%Docstring
+Sets extent and scale parameters
+
+:return: flag whether the parameters are the same as last time
+
+.. versionadded:: 3.18
+%End
+
+    void setCacheImage( const QString &cacheKey,
+                        const QImage &image,
+                        const QList< QgsMapLayer * > &dependentLayers = QList< QgsMapLayer * >() );
 %Docstring
 Set the cached ``image`` for a particular ``cacheKey``. The ``cacheKey`` usually
 matches the :py:func:`QgsMapLayer.id()` which the image is a render of.
@@ -61,11 +78,22 @@ repaint then the cache image will be cleared.
 
     bool hasCacheImage( const QString &cacheKey ) const;
 %Docstring
-Returns ``True`` if the cache contains an image with the specified ``cacheKey``.
+Returns ``True`` if the cache contains an image with the specified ``cacheKey``
+that has the same extent and scale as the cache's global extent and scale
 
 .. seealso:: :py:func:`cacheImage`
 
 .. versionadded:: 3.0
+%End
+
+    bool hasAnyCacheImage( const QString &cacheKey ) const;
+%Docstring
+Returns ``True`` if the cache contains an image with the specified ``cacheKey``
+with any cache's parameters (extent and scale)
+
+.. seealso:: :py:func:`transformedCacheImage`
+
+.. versionadded:: 3.18
 %End
 
     QImage cacheImage( const QString &cacheKey ) const;
@@ -77,6 +105,22 @@ Returns a null image if it is not cached.
 .. seealso:: :py:func:`setCacheImage`
 
 .. seealso:: :py:func:`hasCacheImage`
+%End
+
+    QImage transformedCacheImage( const QString &cacheKey, const QgsRectangle &extent, double scale ) const;
+%Docstring
+Returns the cached image for the specified ``cacheKey`` transformed
+to the particular extent and scale.
+
+The ``cacheKey`` usually matches the :py:func:`QgsMapLayer.id()` which
+the image is a render of.
+Returns a null image if it is not cached.
+
+.. seealso:: :py:func:`setCacheImage`
+
+.. seealso:: :py:func:`hasCacheImageWithAnyParameters`
+
+.. versionadded:: 3.18
 %End
 
     QList< QgsMapLayer * > dependentLayers( const QString &cacheKey ) const;

--- a/python/core/auto_generated/qgsmaprenderercache.sip.in
+++ b/python/core/auto_generated/qgsmaprenderercache.sip.in
@@ -54,7 +54,7 @@ Deprecated, use :py:func:`~QgsMapRendererCache.updateParameters` and :py:func:`~
 :return: flag whether the parameters are the same as last time
 %End
 
-    bool updateParameters( const QgsRectangle &extent, double scale );
+    bool updateParameters( const QgsRectangle &extent, const QgsMapToPixel &mtp );
 %Docstring
 Sets extent and scale parameters
 
@@ -107,7 +107,7 @@ Returns a null image if it is not cached.
 .. seealso:: :py:func:`hasCacheImage`
 %End
 
-    QImage transformedCacheImage( const QString &cacheKey, const QgsRectangle &extent, double scale ) const;
+    QImage transformedCacheImage( const QString &cacheKey, const QgsRectangle &extent, const QgsMapToPixel &mtp ) const;
 %Docstring
 Returns the cached image for the specified ``cacheKey`` transformed
 to the particular extent and scale.

--- a/python/core/auto_generated/qgsmaprendererjob.sip.in
+++ b/python/core/auto_generated/qgsmaprendererjob.sip.in
@@ -190,6 +190,7 @@ emitted when asynchronous rendering is finished (or canceled).
 
 
 
+
 };
 
 

--- a/src/core/qgsmaplayerrenderer.h
+++ b/src/core/qgsmaplayerrenderer.h
@@ -110,9 +110,35 @@ class CORE_EXPORT QgsMapLayerRenderer
      */
     const QgsRenderContext *renderContext() const SIP_SKIP { return mContext; }
 
+    /**
+     * Returns whether the renderer already drawn (at
+     * least partially) some data to resulting image
+     *
+     * \since QGIS 3.18
+     */
+    bool canComposeImage() const { return mCanComposeImage; }
+
   protected:
     QStringList mErrors;
     QString mLayerID;
+
+    // TODO QGIS 4.0 - make false as default
+
+    /**
+     * The flag must be set to false in renderer's constructor
+     * if wants to use the smarter map redraws functionality
+     * https://github.com/qgis/QGIS-Enhancement-Proposals/issues/181
+     *
+     * The flag must be set to true by renderer when
+     * the data is fetched and the renderer actually
+     * started to update the destination image.
+     *
+     * When the flag is set to false, the image from
+     * QgsMapRendererCache is used instead to avoid flickering.
+     *
+     * \since QGIS 3.18
+     */
+    bool mCanComposeImage = true;
 
   private:
 

--- a/src/core/qgsmaplayerrenderer.h
+++ b/src/core/qgsmaplayerrenderer.h
@@ -116,7 +116,7 @@ class CORE_EXPORT QgsMapLayerRenderer
      *
      * \since QGIS 3.18
      */
-    bool canComposeImage() const { return mCanComposeImage; }
+    bool isReadyToCompose() const { return mReadyToCompose; }
 
   protected:
     QStringList mErrors;
@@ -138,7 +138,7 @@ class CORE_EXPORT QgsMapLayerRenderer
      *
      * \since QGIS 3.18
      */
-    bool mCanComposeImage = true;
+    bool mReadyToCompose = true;
 
   private:
 

--- a/src/core/qgsmaprenderercache.cpp
+++ b/src/core/qgsmaprenderercache.cpp
@@ -100,6 +100,7 @@ bool QgsMapRendererCache::init( const QgsRectangle &extent, double scale )
   // set new params
   mExtent = extent;
   mScale = scale;
+  mMtp = QgsMapToPixel::fromScale( scale, QgsUnitTypes::DistanceUnit::DistanceUnknownUnit );
 
   return false;
 }
@@ -116,7 +117,7 @@ bool QgsMapRendererCache::updateParameters( const QgsRectangle &extent, const Qg
   // set new params
 
   mExtent = extent;
-  mScale = 0.0;
+  mScale = 1.0;
   mMtp = mtp;
 
   return false;

--- a/src/core/qgsmaprenderercache.h
+++ b/src/core/qgsmaprenderercache.h
@@ -174,7 +174,7 @@ class CORE_EXPORT QgsMapRendererCache : public QObject
     QgsRectangle mExtent;
     QgsMapToPixel mMtp;
 
-    double mScale; //DEPRECATED
+    double mScale = -1.0; //DEPRECATED
 
     //! Map of cache key to cache parameters
     QMap<QString, CacheParameters> mCachedImages;

--- a/src/core/qgsmaprenderercache.h
+++ b/src/core/qgsmaprenderercache.h
@@ -73,7 +73,7 @@ class CORE_EXPORT QgsMapRendererCache : public QObject
      *
      * \since QGIS 3.18
      */
-    bool updateParameters( const QgsRectangle &extent, double scale );
+    bool updateParameters( const QgsRectangle &extent, const QgsMapToPixel &mtp );
 
     /**
      * Set the cached \a image for a particular \a cacheKey. The \a cacheKey usually
@@ -127,7 +127,7 @@ class CORE_EXPORT QgsMapRendererCache : public QObject
      *
      * \since QGIS 3.18
      */
-    QImage transformedCacheImage( const QString &cacheKey, const QgsRectangle &extent, double scale ) const;
+    QImage transformedCacheImage( const QString &cacheKey, const QgsRectangle &extent, const QgsMapToPixel &mtp ) const;
 
     /**
      * Returns a list of map layers on which an image in the cache depends.
@@ -159,7 +159,7 @@ class CORE_EXPORT QgsMapRendererCache : public QObject
       QImage cachedImage;
       QgsWeakMapLayerPointerList dependentLayers;
       QgsRectangle cachedExtent;
-      double cachedScale = 0;
+      QgsMapToPixel cachedMtp;
     };
 
     //! Invalidate cache contents (without locking)
@@ -172,7 +172,9 @@ class CORE_EXPORT QgsMapRendererCache : public QObject
 
     mutable QMutex mMutex;
     QgsRectangle mExtent;
-    double mScale = 0;
+    QgsMapToPixel mMtp;
+
+    double mScale; //DEPRECATED
 
     //! Map of cache key to cache parameters
     QMap<QString, CacheParameters> mCachedImages;

--- a/src/core/qgsmaprenderercache.h
+++ b/src/core/qgsmaprenderercache.h
@@ -35,6 +35,10 @@
  * If triggered, the cache removes the rendered image (and disconnects from the
  * layers).
  *
+ * When user pans/zooms the canvas, the cache is also used in rendering period
+ * for particular layer after first render update and moment layer actually
+ * partially rendered something in the resulting image
+ *
  * The class is thread-safe (multiple classes can access the same instance safely).
  *
  * \since QGIS 2.4
@@ -53,11 +57,23 @@ class CORE_EXPORT QgsMapRendererCache : public QObject
     void clear();
 
     /**
-     * Initialize cache: set new parameters and clears the cache if any
+     * Initialize cache: sets extent and scale parameters and clears the cache if any
      * parameters have changed since last initialization.
+     *
+     * Deprecated, use updateParameters() and clear()
+     *
      * \returns flag whether the parameters are the same as last time
      */
-    bool init( const QgsRectangle &extent, double scale );
+    bool Q_DECL_DEPRECATED init( const QgsRectangle &extent, double scale ) SIP_DEPRECATED;
+
+    /**
+     * Sets extent and scale parameters
+     *
+     * \returns flag whether the parameters are the same as last time
+     *
+     * \since QGIS 3.18
+     */
+    bool updateParameters( const QgsRectangle &extent, double scale );
 
     /**
      * Set the cached \a image for a particular \a cacheKey. The \a cacheKey usually
@@ -67,14 +83,28 @@ class CORE_EXPORT QgsMapRendererCache : public QObject
      * repaint then the cache image will be cleared.
      * \see cacheImage()
      */
-    void setCacheImage( const QString &cacheKey, const QImage &image, const QList< QgsMapLayer * > &dependentLayers = QList< QgsMapLayer * >() );
+    void setCacheImage( const QString &cacheKey,
+                        const QImage &image,
+                        const QList< QgsMapLayer * > &dependentLayers = QList< QgsMapLayer * >() );
 
     /**
-     * Returns TRUE if the cache contains an image with the specified \a cacheKey.
+     * Returns TRUE if the cache contains an image with the specified \a cacheKey
+     * that has the same extent and scale as the cache's global extent and scale
+     *
      * \see cacheImage()
      * \since QGIS 3.0
      */
     bool hasCacheImage( const QString &cacheKey ) const;
+
+    /**
+     * Returns TRUE if the cache contains an image with the specified \a cacheKey
+     * with any cache's parameters (extent and scale)
+     *
+     * \see transformedCacheImage()
+     *
+     * \since QGIS 3.18
+     */
+    bool hasAnyCacheImage( const QString &cacheKey ) const;
 
     /**
      * Returns the cached image for the specified \a cacheKey. The \a cacheKey usually
@@ -84,6 +114,20 @@ class CORE_EXPORT QgsMapRendererCache : public QObject
      * \see hasCacheImage()
      */
     QImage cacheImage( const QString &cacheKey ) const;
+
+    /**
+     * Returns the cached image for the specified \a cacheKey transformed
+     * to the particular extent and scale.
+     *
+     * The \a cacheKey usually matches the QgsMapLayer::id() which
+     * the image is a render of.
+     * Returns a null image if it is not cached.
+     * \see setCacheImage()
+     * \see hasCacheImageWithAnyParameters()
+     *
+     * \since QGIS 3.18
+     */
+    QImage transformedCacheImage( const QString &cacheKey, const QgsRectangle &extent, double scale ) const;
 
     /**
      * Returns a list of map layers on which an image in the cache depends.
@@ -114,6 +158,8 @@ class CORE_EXPORT QgsMapRendererCache : public QObject
     {
       QImage cachedImage;
       QgsWeakMapLayerPointerList dependentLayers;
+      QgsRectangle cachedExtent;
+      double cachedScale = 0;
     };
 
     //! Invalidate cache contents (without locking)

--- a/src/core/qgsmaprenderercache.h
+++ b/src/core/qgsmaprenderercache.h
@@ -127,7 +127,7 @@ class CORE_EXPORT QgsMapRendererCache : public QObject
      *
      * \since QGIS 3.18
      */
-    QImage transformedCacheImage( const QString &cacheKey, const QgsRectangle &extent, const QgsMapToPixel &mtp ) const;
+    QImage transformedCacheImage( const QString &cacheKey, const QgsMapToPixel &mtp ) const;
 
     /**
      * Returns a list of map layers on which an image in the cache depends.

--- a/src/core/qgsmaprendererjob.cpp
+++ b/src/core/qgsmaprendererjob.cpp
@@ -850,7 +850,7 @@ QImage QgsMapRendererJob::layerImageToBeComposed(
   {
     if ( cache && cache->hasAnyCacheImage( job.layer->id() ) )
     {
-      return cache->transformedCacheImage( job.layer->id(), settings.visibleExtent(), settings.mapToPixel() );
+      return cache->transformedCacheImage( job.layer->id(), settings.mapToPixel() );
     }
     else
       return QImage();

--- a/src/core/qgsmaprendererjob.cpp
+++ b/src/core/qgsmaprendererjob.cpp
@@ -48,6 +48,26 @@
 
 const QString QgsMapRendererJob::LABEL_CACHE_ID = QStringLiteral( "_labels_" );
 
+bool LayerRenderJob::imageCanBeComposed() const
+{
+  //TODO do we need imageInitialized at all?
+  if ( imageInitialized )
+  {
+    if ( renderer )
+    {
+      return renderer->canComposeImage();
+    }
+    else
+    {
+      return true;
+    }
+  }
+  else
+  {
+    return false;
+  }
+}
+
 QgsMapRendererJob::QgsMapRendererJob( const QgsMapSettings &settings )
   : mSettings( settings )
 
@@ -300,7 +320,7 @@ LayerRenderJobs QgsMapRendererJob::prepareJobs( QPainter *painter, QgsLabelingEn
 
   if ( mCache )
   {
-    bool cacheValid = mCache->init( mSettings.visibleExtent(), mSettings.scale() );
+    bool cacheValid = mCache->updateParameters( mSettings.visibleExtent(), mSettings.scale() );
     Q_UNUSED( cacheValid )
     QgsDebugMsgLevel( QStringLiteral( "CACHE VALID: %1" ).arg( cacheValid ), 4 );
   }
@@ -740,7 +760,12 @@ void QgsMapRendererJob::cleanupLabelJob( LabelRenderJob &job )
 
 #define DEBUG_RENDERING 0
 
-QImage QgsMapRendererJob::composeImage( const QgsMapSettings &settings, const LayerRenderJobs &jobs, const LabelRenderJob &labelJob )
+QImage QgsMapRendererJob::composeImage(
+  const QgsMapSettings &settings,
+  const LayerRenderJobs &jobs,
+  const LabelRenderJob &labelJob,
+  const QgsMapRendererCache *cache
+)
 {
   QImage image( settings.deviceOutputSize(), settings.outputImageFormat() );
   image.setDevicePixelRatio( settings.devicePixelRatio() );
@@ -760,19 +785,19 @@ QImage QgsMapRendererJob::composeImage( const QgsMapSettings &settings, const La
     if ( job.layer && job.layer->customProperty( QStringLiteral( "rendering/renderAboveLabels" ) ).toBool() )
       continue; // skip layer for now, it will be rendered after labels
 
-    if ( !job.imageInitialized )
-      continue; // img not safe to compose
+    QImage img = layerImageToBeComposed( settings, job, cache );
+    if ( img.isNull() )
+      continue; // image is not prepared and not even in cache
 
     painter.setCompositionMode( job.blendMode );
     painter.setOpacity( job.opacity );
 
 #if DEBUG_RENDERING
-    job.img->save( QString( "/tmp/final_%1.png" ).arg( i ) );
+    img->save( QString( "/tmp/final_%1.png" ).arg( i ) );
     i++;
 #endif
-    Q_ASSERT( job.img );
 
-    painter.drawImage( 0, 0, *job.img );
+    painter.drawImage( 0, 0, img );
   }
 
   // IMPORTANT - don't draw labelJob img before the label job is complete,
@@ -793,15 +818,14 @@ QImage QgsMapRendererJob::composeImage( const QgsMapSettings &settings, const La
     if ( !job.layer || !job.layer->customProperty( QStringLiteral( "rendering/renderAboveLabels" ) ).toBool() )
       continue;
 
-    if ( !job.imageInitialized )
-      continue; // img not safe to compose
+    QImage img = layerImageToBeComposed( settings, job, cache );
+    if ( img.isNull() )
+      continue; // image is not prepared and not even in cache
 
     painter.setCompositionMode( job.blendMode );
     painter.setOpacity( job.opacity );
 
-    Q_ASSERT( job.img );
-
-    painter.drawImage( 0, 0, *job.img );
+    painter.drawImage( 0, 0, img );
   }
 
   painter.end();
@@ -809,6 +833,28 @@ QImage QgsMapRendererJob::composeImage( const QgsMapSettings &settings, const La
   image.save( "/tmp/final.png" );
 #endif
   return image;
+}
+
+QImage QgsMapRendererJob::layerImageToBeComposed(
+  const QgsMapSettings &settings,
+  const LayerRenderJob &job,
+  const QgsMapRendererCache *cache
+)
+{
+  if ( job.imageCanBeComposed() )
+  {
+    Q_ASSERT( job.img );
+    return *job.img;
+  }
+  else
+  {
+    if ( cache && cache->hasAnyCacheImage( job.layer->id() ) )
+    {
+      return cache->transformedCacheImage( job.layer->id(), settings.visibleExtent(), settings.scale() );
+    }
+    else
+      return QImage();
+  }
 }
 
 void QgsMapRendererJob::composeSecondPass( LayerRenderJobs &secondPassJobs, LabelRenderJob &labelJob )

--- a/src/core/qgsmaprendererjob.cpp
+++ b/src/core/qgsmaprendererjob.cpp
@@ -320,7 +320,7 @@ LayerRenderJobs QgsMapRendererJob::prepareJobs( QPainter *painter, QgsLabelingEn
 
   if ( mCache )
   {
-    bool cacheValid = mCache->updateParameters( mSettings.visibleExtent(), mSettings.scale() );
+    bool cacheValid = mCache->updateParameters( mSettings.visibleExtent(), mSettings.mapToPixel() );
     Q_UNUSED( cacheValid )
     QgsDebugMsgLevel( QStringLiteral( "CACHE VALID: %1" ).arg( cacheValid ), 4 );
   }
@@ -850,7 +850,7 @@ QImage QgsMapRendererJob::layerImageToBeComposed(
   {
     if ( cache && cache->hasAnyCacheImage( job.layer->id() ) )
     {
-      return cache->transformedCacheImage( job.layer->id(), settings.visibleExtent(), settings.scale() );
+      return cache->transformedCacheImage( job.layer->id(), settings.visibleExtent(), settings.mapToPixel() );
     }
     else
       return QImage();

--- a/src/core/qgsmaprendererjob.cpp
+++ b/src/core/qgsmaprendererjob.cpp
@@ -55,7 +55,7 @@ bool LayerRenderJob::imageCanBeComposed() const
   {
     if ( renderer )
     {
-      return renderer->canComposeImage();
+      return renderer->isReadyToCompose();
     }
     else
     {

--- a/src/core/qgsmaprendererjob.h
+++ b/src/core/qgsmaprendererjob.h
@@ -53,8 +53,11 @@ struct LayerRenderJob
    * May be NULLPTR if it is not necessary to draw to separate image (e.g. sequential rendering).
    */
   QImage *img;
-  //! TRUE when img has been initialized (filled with transparent pixels) and is safe to compose
+  //! TRUE when img has been initialized (filled with transparent pixels)
   bool imageInitialized = false;
+
+  bool imageCanBeComposed() const;
+
   QgsMapLayerRenderer *renderer; // must be deleted
   QPainter::CompositionMode blendMode;
   double opacity;
@@ -366,7 +369,13 @@ class CORE_EXPORT QgsMapRendererJob : public QObject
     LayerRenderJobs prepareSecondPassJobs( LayerRenderJobs &firstPassJobs, LabelRenderJob &labelJob ) SIP_SKIP;
 
     //! \note not available in Python bindings
-    static QImage composeImage( const QgsMapSettings &settings, const LayerRenderJobs &jobs, const LabelRenderJob &labelJob ) SIP_SKIP;
+    static QImage composeImage( const QgsMapSettings &settings,
+                                const LayerRenderJobs &jobs,
+                                const LabelRenderJob &labelJob,
+                                const QgsMapRendererCache *cache = nullptr ) SIP_SKIP;
+
+    //! \note not available in Python bindings
+    static QImage layerImageToBeComposed( const QgsMapSettings &settings, const LayerRenderJob &job, const QgsMapRendererCache *cache ) SIP_SKIP;
 
     /**
      * Compose second pass images into first pass images.

--- a/src/core/qgsmaprendererparalleljob.cpp
+++ b/src/core/qgsmaprendererparalleljob.cpp
@@ -210,7 +210,7 @@ QgsLabelingResults *QgsMapRendererParallelJob::takeLabelingResults()
 QImage QgsMapRendererParallelJob::renderedImage()
 {
   if ( mStatus == RenderingLayers )
-    return composeImage( mSettings, mLayerJobs, mLabelJob );
+    return composeImage( mSettings, mLayerJobs, mLabelJob, mCache );
   else
     return mFinalImage; // when rendering labels or idle
 }

--- a/src/core/qgsmaprendererparalleljob.cpp
+++ b/src/core/qgsmaprendererparalleljob.cpp
@@ -331,6 +331,12 @@ void QgsMapRendererParallelJob::renderLayersSecondPassFinished()
   emit finished();
 }
 
+/*
+ * See section "Smarter Map Redraws"
+ * in https://github.com/qgis/QGIS-Enhancement-Proposals/issues/181
+ */
+#define SIMULATE_SLOW_RENDERER
+
 void QgsMapRendererParallelJob::renderLayerStatic( LayerRenderJob &job )
 {
   if ( job.context.renderingStopped() )
@@ -350,6 +356,9 @@ void QgsMapRendererParallelJob::renderLayerStatic( LayerRenderJob &job )
   QgsDebugMsgLevel( QStringLiteral( "job %1 start (layer %2)" ).arg( reinterpret_cast< quint64 >( &job ), 0, 16 ).arg( job.layerId ), 2 );
   try
   {
+#ifdef SIMULATE_SLOW_RENDERER
+    QThread::sleep( 1 );
+#endif
     job.renderer->render();
   }
   catch ( QgsException &e )

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -68,7 +68,12 @@ QgsRasterLayerRenderer::QgsRasterLayerRenderer( QgsRasterLayer *layer, QgsRender
   , mProviderCapabilities( static_cast<QgsRasterDataProvider::Capability>( layer->dataProvider()->capabilities() ) )
   , mFeedback( new QgsRasterLayerRendererFeedback( this ) )
 {
-  mCanComposeImage = false;
+  if ( !( rendererContext.flags() & QgsRenderContext::RenderPreviewJob )
+       && !( rendererContext.flags() & QgsRenderContext::Render3DMap ) )
+  {
+    // do not use smart canvas updates for raster tiles and 3d
+    mCanComposeImage = false;
+  }
 
   QgsMapToPixel mapToPixel = rendererContext.mapToPixel();
   if ( rendererContext.mapToPixel().mapRotation() )
@@ -233,7 +238,9 @@ QgsRasterLayerRenderer::QgsRasterLayerRenderer( QgsRasterLayer *layer, QgsRender
   if ( rasterRenderer
        && !( rendererContext.flags() & QgsRenderContext::RenderPreviewJob )
        && !( rendererContext.flags() & QgsRenderContext::Render3DMap ) )
+  {
     layer->refreshRendererIfNeeded( rasterRenderer, rendererContext.extent() );
+  }
 
   const QgsRasterLayerTemporalProperties *temporalProperties = qobject_cast< const QgsRasterLayerTemporalProperties * >( layer->temporalProperties() );
   if ( temporalProperties->isActive() && renderContext()->isTemporal() )

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -68,6 +68,8 @@ QgsRasterLayerRenderer::QgsRasterLayerRenderer( QgsRasterLayer *layer, QgsRender
   , mProviderCapabilities( static_cast<QgsRasterDataProvider::Capability>( layer->dataProvider()->capabilities() ) )
   , mFeedback( new QgsRasterLayerRendererFeedback( this ) )
 {
+  mCanComposeImage = false;
+
   QgsMapToPixel mapToPixel = rendererContext.mapToPixel();
   if ( rendererContext.mapToPixel().mapRotation() )
   {
@@ -330,6 +332,7 @@ bool QgsRasterLayerRenderer::render()
   }
 
   QgsDebugMsgLevel( QStringLiteral( "total raster draw time (ms):     %1" ).arg( time.elapsed(), 5 ), 4 );
+  mCanComposeImage = true;
 
   return true;
 }

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -68,13 +68,6 @@ QgsRasterLayerRenderer::QgsRasterLayerRenderer( QgsRasterLayer *layer, QgsRender
   , mProviderCapabilities( static_cast<QgsRasterDataProvider::Capability>( layer->dataProvider()->capabilities() ) )
   , mFeedback( new QgsRasterLayerRendererFeedback( this ) )
 {
-  if ( !( rendererContext.flags() & QgsRenderContext::RenderPreviewJob )
-       && !( rendererContext.flags() & QgsRenderContext::Render3DMap ) )
-  {
-    // do not use smart canvas updates for raster tiles and 3d
-    mCanComposeImage = false;
-  }
-
   QgsMapToPixel mapToPixel = rendererContext.mapToPixel();
   if ( rendererContext.mapToPixel().mapRotation() )
   {
@@ -339,7 +332,7 @@ bool QgsRasterLayerRenderer::render()
   }
 
   QgsDebugMsgLevel( QStringLiteral( "total raster draw time (ms):     %1" ).arg( time.elapsed(), 5 ), 4 );
-  mCanComposeImage = true;
+  mReadyToCompose = true;
 
   return true;
 }

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -183,6 +183,7 @@ set(TESTS
  testqgsmaplayerstylemanager.cpp
  testqgsmaplayer.cpp
  testqgsmaprendererjob.cpp
+ testqgsmaprenderercache.cpp
  testqgsmaprotation.cpp
  testqgsmapsettings.cpp
  testqgsmapsettingsutils.cpp

--- a/tests/src/core/testqgsmaprenderercache.cpp
+++ b/tests/src/core/testqgsmaprenderercache.cpp
@@ -1,0 +1,130 @@
+/***************************************************************************
+     testqgsmaprenderercache.cpp
+     --------------------------------------
+    Date                 : January 2021
+    Copyright            : (C) 2021 by Peter Petrik
+    Email                : zilolv at gmail.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgstest.h"
+
+#include <QImage>
+
+#include "qgsmaprenderercache.h"
+#include "qgsmaptopixel.h"
+#include "qgsrectangle.h"
+
+class TestQgsMapRendereCache: public QObject
+{
+    Q_OBJECT
+
+  public:
+    TestQgsMapRendereCache();
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+    void init(); // will be called before each testfunction is executed.
+    void cleanup(); // will be called after every testfunction.
+
+    void testCache();
+};
+
+
+TestQgsMapRendereCache::TestQgsMapRendereCache() = default;
+
+void TestQgsMapRendereCache::initTestCase()
+{
+  QgsApplication::init();
+  QgsApplication::initQgis();
+}
+
+void TestQgsMapRendereCache::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsMapRendereCache::init()
+{
+}
+
+void TestQgsMapRendereCache::cleanup()
+{
+}
+
+void TestQgsMapRendereCache::testCache()
+{
+  QgsMapRendererCache cache;
+  QImage imgRed( 100, 100, QImage::Format::Format_ARGB32_Premultiplied );
+  imgRed.fill( Qt::red );
+  const QString imgRedKey( "red" );
+
+  QImage imgBlue( 50, 50, QImage::Format::Format_ARGB32_Premultiplied );
+  imgBlue.fill( Qt::blue );
+  const QString imgBlueKey( "blue" );
+
+  /* the cache images are same as inserted */
+  QgsRectangle extent1( 0, 0, 100, 200 );
+  QgsMapToPixel mtp1( 1, 50, 50, 100, 100, 0.0 );
+  cache.updateParameters( extent1, mtp1 );
+
+  QVERIFY( !cache.hasCacheImage( imgBlueKey ) );
+
+  cache.setCacheImage( imgBlueKey, imgBlue );
+  QVERIFY( !cache.hasCacheImage( imgRedKey ) );
+  QVERIFY( cache.hasCacheImage( imgBlueKey ) );
+  QVERIFY( cache.hasAnyCacheImage( imgBlueKey ) );
+
+  cache.setCacheImage( imgRedKey, imgRed );
+  QVERIFY( cache.hasCacheImage( imgRedKey ) );
+  QVERIFY( cache.hasCacheImage( imgBlueKey ) );
+  QVERIFY( cache.hasAnyCacheImage( imgBlueKey ) );
+  QVERIFY( cache.hasAnyCacheImage( imgRedKey ) );
+
+  {
+    QImage img = cache.cacheImage( imgBlueKey );
+    QVERIFY( img.size() == imgBlue.size() );
+    QVERIFY( img.pixelColor( 10, 20 ) == Qt::blue );
+
+    QImage transformed = cache.transformedCacheImage( imgBlueKey, mtp1 );
+    QVERIFY( transformed.size() == imgBlue.size() );
+    QVERIFY( img.pixelColor( 10, 20 ) == Qt::blue );
+  }
+
+  /* the cache images are transformed */
+  QgsRectangle extent2( 20, 0, 120, 200 );
+  QgsMapToPixel mtp2( 1, 70, 50, 100, 100, 0.0 ); // move by 20
+  cache.updateParameters( extent2, mtp2 );
+  QVERIFY( !cache.hasCacheImage( imgRedKey ) );
+  QVERIFY( !cache.hasCacheImage( imgBlueKey ) );
+  QVERIFY( cache.hasAnyCacheImage( imgBlueKey ) );
+  QVERIFY( cache.hasAnyCacheImage( imgRedKey ) );
+
+  QImage transformed = cache.transformedCacheImage( imgBlueKey, mtp2 );
+  QVERIFY( transformed.pixelColor( 30, 20 ) == Qt::transparent );
+  QVERIFY( transformed.pixelColor( 10, 20 ) == Qt::blue );
+
+  /* we can replace the cache image */
+  cache.setCacheImage( imgBlueKey, transformed );
+  QVERIFY( cache.hasCacheImage( imgBlueKey ) );
+  QVERIFY( cache.hasAnyCacheImage( imgBlueKey ) );
+
+  /* clear the cache */
+  cache.clearCacheImage( imgBlueKey );
+  QVERIFY( !cache.hasCacheImage( imgBlueKey ) );
+  QVERIFY( !cache.hasAnyCacheImage( imgBlueKey ) );
+
+  cache.clear();
+  QVERIFY( !cache.hasCacheImage( imgRedKey ) );
+  QVERIFY( !cache.hasAnyCacheImage( imgRedKey ) );
+}
+
+
+QGSTEST_MAIN( TestQgsMapRendereCache )
+#include "testqgsmaprenderercache.moc"


### PR DESCRIPTION
https://github.com/qgis/QGIS-Enhancement-Proposals/issues/181

TODO

- [x] move/scale image in QgsMapRendererCache::transformedCacheImage
- [ ] go through other renderer types (vector, mesh) and assign `mCanComposeImage` correctly
- [ ] fix OSM raster tiles (now there are not displayed-as-they-go)
- [ ] tests?